### PR TITLE
Updated values for pass and fail

### DIFF
--- a/src/ConsoleDialogs/rawdialogs.py
+++ b/src/ConsoleDialogs/rawdialogs.py
@@ -97,8 +97,8 @@ class PassFailDialog(object):
     @ConsoleIO()
     def show(self):
         possible = {
-            'p': False,
-            'f': True
+            'f': False,
+            'p': True
         }
         show_message(self.message)
         while True:


### PR DESCRIPTION
P and F had reversed logic where typing P would fail the test and typing F would pass the test, this has now been sorted so that P will Pass the test and F will fail the test.